### PR TITLE
Update .travis.yml to use main branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,4 +13,4 @@ deploy:
   keep-history: true
   github-token: $GITHUB_TOKEN
   on:
-    branch: master
+    branch: main


### PR DESCRIPTION
This PR updates the .travis.yml file to use the `main` branch instead of `master`. It has been automatically generated and this might not have worked correctly, so please check it carefully.